### PR TITLE
Potential fix to bug: wrong label on Reddit link (#1118)

### DIFF
--- a/source/PlayniteServices/Models/IGDB/IGDB.cs
+++ b/source/PlayniteServices/Models/IGDB/IGDB.cs
@@ -20,7 +20,9 @@ namespace PlayniteServices.Models.IGDB
         Iphone = 10,
         Ipad = 11,
         Android = 12,
-        Steam = 13
+        Steam = 13,
+        Reddit = 14,
+        Discord = 15
     }
 
     public enum GameCategory : ulong


### PR DESCRIPTION
Add Reddit with its value to WebsiteCategory enum. Also add Discord,
as some games might have it later on. Values for both are from the IGDB
api docs.

Resolves: #1103